### PR TITLE
Update validate-themes.yml

### DIFF
--- a/.github/workflows/validate-themes.yml
+++ b/.github/workflows/validate-themes.yml
@@ -16,6 +16,9 @@ jobs:
 
       - name: Install Node.js
         uses: actions/setup-node@v4
+        
+      - name: Override registry
+        run: yarn config set registry "https://registry.npmjs.org"
 
       - uses: mskelton/setup-yarn@v3
 


### PR DESCRIPTION
The validate changes pipeline is not working with the setup-yarn searching for the yarn inside https://registry.yarnpkg.com, this change can move the registry for the npm, avoiding the 500 error.