### PR TITLE
Fix Hydra Station 5 theme to not use imgur for UK users

### DIFF
--- a/themes/HydraStation 5-x5kOOW5V/theme.css
+++ b/themes/HydraStation 5-x5kOOW5V/theme.css
@@ -29,7 +29,7 @@ body {
     /* Slightly increase letter spacing */
     line-height: 1.5;
     /* Improved line height */
-    background-image: url('https://i.imgur.com/uxUtjsa.jpeg');
+    background-image: url('https://cdn.nest.rip/uploads/fb1740d5-4ec8-4f13-8697-ad582d1a6547.jpg');
     background-size: cover;
     background-position: left;
     background-repeat: no-repeat;


### PR DESCRIPTION
Replaced default imgur.com link with a nest.rip link. Default imgur.com link currently shows as "Content not viewable in your region" for UK users. See https://cdn.nest.rip/uploads/93f20f5c-2103-4742-905c-69c917b691ef.png for example.

**When submitting this pull request, I confirm the following (please check the boxes):**

- [x] I have read and understood the [Hydra Themes Docs](https://docs.hydralauncher.gg/themes.html).
- [x] I have checked that the folder of my theme contains my friend code in the format "My Awesome Theme-_my_friend_code_".
- [x] I have checked that the screeshot file has one of the following extensions: png, webp, jpg, jpeg, avif, heic, heif.
- [x] I have checked that my css file has the extension ".css".
- [x] I am aware that the validation pipeline needs to pass with success for my theme to be approved.

Good example of how files should be in the PR:

![Example of files in a good PR](https://raw.githubusercontent.com/hydralauncher/hydra-themes/f61313ffdf4f1d5cfd2149583a02eb4da4e6c530/docs/pr-example.png)
