### PR TITLE
fix: use consistent achievement support labels on theme cards

### DIFF
--- a/src/components/ui/theme-card.tsx
+++ b/src/components/ui/theme-card.tsx
@@ -262,7 +262,7 @@ export function ThemeCard({ theme }: Readonly<ThemeCardProps>) {
                 <>
                   <XCircleIcon className="size-4 text-red-500" />
                   <span className="text-xs text-muted-foreground">
-                    Does not support Achievements
+                    Custom Achievement
                   </span>
                 </>
               )}
@@ -281,7 +281,7 @@ export function ThemeCard({ theme }: Readonly<ThemeCardProps>) {
                   <>
                     <XCircleIcon className="size-4 text-red-500" />
                     <span className="text-xs text-muted-foreground">
-                      Does not support Achievement Sound
+                      Custom Achievement Sound
                     </span>
                   </>
                 )}


### PR DESCRIPTION
The unsupported states read "Does not support Achievements" and "Does not support Achievement Sound", which was easy to misread as a claim about the feature itself rather than about the theme. Both states now use the same wording, with the icon carrying the supported/unsupported distinction.

**When submitting this pull request, I confirm the following (please check the boxes):**

- [ ] I have read and understood the [Hydra Themes Docs](https://docs.hydralauncher.gg/themes.html).
- [ ] I have checked that the folder of my theme contains my friend code in the format "My Awesome Theme-_my_friend_code_".
- [ ] I have checked that the screeshot file has one of the following extensions: png, webp, jpg, jpeg, avif, heic, heif.
- [ ] I have checked that my css file has the extension ".css".
- [ ] I am aware that the validation pipeline needs to pass with success for my theme to be approved.

Good example of how files should be in the PR:

![Example of files in a good PR](https://raw.githubusercontent.com/hydralauncher/hydra-themes/f61313ffdf4f1d5cfd2149583a02eb4da4e6c530/docs/pr-example.png)
